### PR TITLE
ERC721 TransferFrom inside BaseRegistrar - ENG-13

### DIFF
--- a/src/registrar/types/BaseRegistrar.sol
+++ b/src/registrar/types/BaseRegistrar.sol
@@ -321,6 +321,12 @@ contract BaseRegistrar is ERC721, Ownable {
         emit ContractURIUpdated();
     }
 
+    /// @notice transferFrom is overridden to handle the registry update.
+    function transferFrom(address from, address to, uint256 tokenId) public override {
+        super.transferFrom(from, to, tokenId);
+        registry.setSubnodeOwner(baseNode, bytes32(tokenId), to);
+    }
+
     /// Internal Methods -------------------------------------------------
 
     /// @notice Register a name and possibly update the Registry.

--- a/test/Flow.t.sol
+++ b/test/Flow.t.sol
@@ -397,6 +397,28 @@ contract FlowTest is BaseTest {
         assertEq(text, "_cien_", "text record set and resolved");
     }
 
+    // ERC721 TESTS ------------------------------------------------------------------------------------------------------
+
+    function test_ERC721_transferFrom_updates_registry() public prank(alice) {
+        bytes32 node = registerAndSetAddr(alice);
+        baseRegistrar.transferFrom(alice, bob, uint256(keccak256(bytes("cien"))));
+        assertEq(baseRegistrar.ownerOf(uint256(keccak256(bytes("cien")))), address(bob), "token owner is bob");
+        assertEq(registry.owner(node), address(bob), "registry owner is bob");
+    }
+
+    function test_ERC721_transferFrom_allows_new_owner_to_set_record_without_explicit_reclaim() public {
+        vm.startPrank(alice);
+        bytes32 node = registerAndSetAddr(alice);
+        baseRegistrar.transferFrom(alice, bob, uint256(keccak256(bytes("cien"))));
+        vm.stopPrank();
+        vm.startPrank(bob);
+        resolver.setAddr(node, address(bob));
+        resolver.setText(node, "com.discord", "_cien_");
+        assertEq(resolver.addr(node), address(bob), "addr is bob");
+        assertEq(resolver.text(node, "com.discord"), "_cien_", "text record set");
+        vm.stopPrank();
+    }
+
     // UTILITIES ----------------------------------------------------------------------------------------------------------
 
     /// @notice Calculate the node for a given label and parent


### PR DESCRIPTION
Overridden the ERC721 `transferFrom` inside the BaseRegistrar in order to also handling the updating of the BNSRegistry, aligning the  registry node owner with the new token owner.
Added also some tests.

Idk why the CI is failing, locally everything seems to just work.
I've reproduced the same steps of the CI. 