### PR TITLE
optimise gas and add comments to reserved registrar

### DIFF
--- a/src/registrar/types/ReservedRegistry.sol
+++ b/src/registrar/types/ReservedRegistry.sol
@@ -25,6 +25,8 @@ contract ReservedRegistry is Ownable, IReservedRegistry {
 
     /// Admin Functions  ---------------------------------------------------
 
+    /// @dev Sets a reserved name.
+    /// @param name_ The name to set as reserved.
     function setReservedName(string calldata name_) public onlyOwner {
         bytes32 labelHash_ = keccak256(abi.encodePacked(name_));
         _reservedNames[labelHash_] = name_;
@@ -32,10 +34,14 @@ contract ReservedRegistry is Ownable, IReservedRegistry {
         _reservedNamesCount++;
     }
 
+    /// @dev Removes a reserved name.
+    /// @param index_ The index of the reserved name to remove.
+    /// @dev After deleting the name, we swap the last element in the array with the one we are deleting to avoid re-indexing.
     function removeReservedName(uint256 index_) public onlyOwner {
         bytes32 labelHash_ = _reservedNamesList[index_];
         delete _reservedNames[labelHash_];
         _reservedNamesList[index_] = _reservedNamesList[_reservedNamesCount - 1];
+        _reservedNamesList.pop();
         _reservedNamesCount--;
     }
 

--- a/src/registrar/types/ReservedRegistry.sol
+++ b/src/registrar/types/ReservedRegistry.sol
@@ -15,6 +15,9 @@ contract ReservedRegistry is Ownable, IReservedRegistry {
     /// @dev Thrown when a name is already reserved.
     error NameAlreadyReserved(string name);
 
+    /// @dev Thrown when the index is out of bounds.
+    error IndexOutOfBounds();
+
     /// State ------------------------------------------------------------
 
     mapping(bytes32 => string) private _reservedNames;
@@ -45,6 +48,8 @@ contract ReservedRegistry is Ownable, IReservedRegistry {
     /// @param index_ The index of the reserved name to remove.
     /// @dev After deleting the name, we swap the last element in the array with the one we are deleting to avoid re-indexing.
     function removeReservedName(uint256 index_) public onlyOwner {
+        if (index_ >= _reservedNamesCount) revert IndexOutOfBounds();
+
         bytes32 labelHash_ = _reservedNamesList[index_];
         delete _reservedNames[labelHash_];
         _reservedNamesList[index_] = _reservedNamesList[_reservedNamesCount - 1];

--- a/src/registrar/types/ReservedRegistry.sol
+++ b/src/registrar/types/ReservedRegistry.sol
@@ -10,6 +10,11 @@ import {StringUtils} from "src/utils/StringUtils.sol";
 contract ReservedRegistry is Ownable, IReservedRegistry {
     using StringUtils for string;
 
+    /// Errors -----------------------------------------------------------
+
+    /// @dev Thrown when a name is already reserved.
+    error NameAlreadyReserved(string name);
+
     /// State ------------------------------------------------------------
 
     mapping(bytes32 => string) private _reservedNames;
@@ -29,6 +34,8 @@ contract ReservedRegistry is Ownable, IReservedRegistry {
     /// @param name_ The name to set as reserved.
     function setReservedName(string calldata name_) public onlyOwner {
         bytes32 labelHash_ = keccak256(abi.encodePacked(name_));
+        if (isReservedName(name_)) revert NameAlreadyReserved(name_);
+
         _reservedNames[labelHash_] = name_;
         _reservedNamesList.push(labelHash_);
         _reservedNamesCount++;


### PR DESCRIPTION
The current implementation of the removeReservedName function in the ReservedRegistry contract swaps the element to be removed with the last one in the _reservedNamesList, but it does not properly shrink the list afterward. The list continues to grow with each removal, leading to inefficiencies and an inaccurate count of reserved names. This can cause increasing gas usage over time and discrepancies in the contract's internal state.