### PR TITLE
disallow reverse record for reserved registrar

### DIFF
--- a/src/registrar/Registrar.sol
+++ b/src/registrar/Registrar.sol
@@ -73,6 +73,9 @@ contract RegistrarController is Ownable, ReentrancyGuard {
     /// @notice Thrown when the launch time is in the past.
     error LaunchTimeInPast();
 
+    /// @notice Thrown when a reverse record is not allowed for reserved names.
+    error ReverseRecordNotAllowedForReservedNames();
+
     /// Events -----------------------------------------------------------
 
     /// @notice Emitted when an ETH payment was processed successfully.
@@ -424,6 +427,7 @@ contract RegistrarController is Ownable, ReentrancyGuard {
             revert NotAuthorisedToMintReservedNames();
         }
         if (!reservedRegistry.isReservedName(request.name)) revert NameNotReserved();
+        if (request.reverseRecord) revert ReverseRecordNotAllowedForReservedNames();
 
         _registerRequest(request);
     }

--- a/test/registrar/ReservedRegistrar.t.sol
+++ b/test/registrar/ReservedRegistrar.t.sol
@@ -10,6 +10,7 @@ contract ReservedRegistrarTest is SystemTest {
     function test_name_reserved_mint__success() public {
         address minter = makeAddr("minter");
         RegistrarController.RegisterRequest memory req = defaultRequest();
+        req.reverseRecord = false;
 
         // add to reserved names
         vm.prank(deployer);


### PR DESCRIPTION
Reserved registrar should not be able to set the reverse record because _setReverseRecord uses msg.sender and could lead to undesired behaviours