### PR TITLE
check for overflow

### DIFF
--- a/src/auction/BeraAuctionHouse.sol
+++ b/src/auction/BeraAuctionHouse.sol
@@ -498,12 +498,12 @@ contract BeraAuctionHouse is IBeraAuctionHouse, Pausable, ReentrancyGuard, Ownab
     /**
      * @dev Convert an ETH price of 256 bits with 18 decimals, to 64 bits with 10 decimals.
      * Max supported value is 1844674407.3709551615 ETH.
-     *
      */
     function ethPriceToUint64(uint256 ethPrice) internal pure returns (uint64) {
-        if (ethPrice > type(uint64).max * 1e8) revert PriceExceedsUint64Range(ethPrice);
+        uint256 scaled = ethPrice / 1e8;
+        if (scaled > type(uint64).max) revert PriceExceedsUint64Range(ethPrice);
 
-        return uint64(ethPrice / 1e8);
+        return uint64(scaled);
     }
 
     /**

--- a/src/auction/BeraAuctionHouse.sol
+++ b/src/auction/BeraAuctionHouse.sol
@@ -501,6 +501,8 @@ contract BeraAuctionHouse is IBeraAuctionHouse, Pausable, ReentrancyGuard, Ownab
      *
      */
     function ethPriceToUint64(uint256 ethPrice) internal pure returns (uint64) {
+        if (ethPrice > type(uint64).max * 1e8) revert PriceExceedsUint64Range(ethPrice);
+
         return uint64(ethPrice / 1e8);
     }
 

--- a/src/auction/interfaces/IBeraAuctionHouse.sol
+++ b/src/auction/interfaces/IBeraAuctionHouse.sol
@@ -47,6 +47,9 @@ interface IBeraAuctionHouse {
     /// @notice Thrown when the reserve price is being set to 0.
     error InvalidReservePrice();
 
+    /// @notice Thrown when the price exceeds the uint64 range.
+    error PriceExceedsUint64Range(uint256 price);
+
     struct Auction {
         uint256 tokenId;
         uint256 amount;


### PR DESCRIPTION
The ethPriceToUint64 function in the BeraAuctionHouse contract converts a BERA price of 256 bits with 18 decimals to a 64-bit value with 10 decimals. However, this function lacks validation to ensure that the result of the division (ethPrice / 1e8) fits within the range of a uint64 (maximum value of 18446744073709551615).

If the division result exceeds the maximum value of uint64, Solidity does not revert. Instead, it silently truncates the value to fit within the uint64 range, potentially leading to incorrect data storage and calculations.

This can result in incorrect values, which may have downstream effects, such as incorrect pricing or settlement logic in the protocol.