### PR TITLE
add non reentrant

### DIFF
--- a/src/auction/BeraAuctionHouse.sol
+++ b/src/auction/BeraAuctionHouse.sol
@@ -111,7 +111,7 @@ contract BeraAuctionHouse is IBeraAuctionHouse, Pausable, ReentrancyGuard, Ownab
      * @notice Settle the current auction.
      * @dev This function can only be called when the contract is paused.
      */
-    function settleAuction() external override whenPaused onlyOwner {
+    function settleAuction() external override whenPaused onlyOwner nonReentrant {
         _settleAuction();
     }
 


### PR DESCRIPTION
BeraAuctionHouse._settleAuction: In this function, the ERC721 token is transferred using base.transferFrom(address(this), _auction.bidder, _auction.tokenId), followed by the payment transfer to paymentReceiver using _safeTransferETHWithFallback. This sequence opens up a potential reentrancy risk because the transfer of the ERC721 token could trigger hooks or malicious fallback logic on the receiver's side. If paymentReceiver is a contract with a reentrant fallback function, it could exploit the auction state during the ETH transfer. Additionally, while auctionStorage.settled = true mitigates some risk, the state transition alone is insufficient without a reentrancy guard, as external interactions during token transfers are inherently unsafe.