### PR TITLE
add explicit hex validation

### DIFF
--- a/src/resolver/UniversalResolver.sol
+++ b/src/resolver/UniversalResolver.sol
@@ -31,6 +31,9 @@ error InvalidRegistry();
 /// @notice Thrown when the array lengths do not match.
 error ArrayLengthsMustMatch();
 
+/// @notice Thrown when the encrypted label length is invalid.
+error InvalidEncryptedLabelLength();
+
 struct MulticallData {
     bytes name;
     bytes[] data;
@@ -341,8 +344,24 @@ contract UniversalResolver is ERC165, Ownable {
             // 0x5d == ']'
             labelLength == 66 && name[offset + 1] == 0x5b && name[nextLabel - 1] == 0x5d
         ) {
-            // Encrypted label
-            (labelHash,) = bytes(name[offset + 2:nextLabel - 1]).hexStringToBytes32(0, 64);
+            // Validate the hex string is exactly 64 characters
+            bytes memory hexString = bytes(name[offset + 2:nextLabel - 1]);
+            if (hexString.length != 64) revert InvalidEncryptedLabelLength();
+
+            // Validate all characters are valid hex
+            for (uint256 i = 0; i < 64; i++) {
+                bytes1 char = hexString[i];
+                if (
+                    !(char >= 0x30 && char <= 0x39) // 0-9
+                        && !(char >= 0x41 && char <= 0x46) // A-F
+                        && !(char >= 0x61 && char <= 0x66) // a-f
+                ) {
+                    revert("Invalid hex character in encrypted label");
+                }
+            }
+
+            // Convert validated hex string to bytes32
+            (labelHash,) = hexString.hexStringToBytes32(0, 64);
         } else {
             labelHash = keccak256(name[offset + 1:nextLabel]);
         }

--- a/src/resolver/UniversalResolver.sol
+++ b/src/resolver/UniversalResolver.sol
@@ -333,10 +333,21 @@ contract UniversalResolver is ERC165, Ownable {
     }
 
     function findResolver(bytes calldata name, uint256 offset) internal view returns (address, bytes32, uint256) {
+        // Add bounds checking for offset
+        if (offset >= name.length) {
+            return (address(0), bytes32(0), offset);
+        }
+
         uint256 labelLength = uint256(uint8(name[offset]));
         if (labelLength == 0) {
             return (address(0), bytes32(0), offset);
         }
+
+        // Add bounds checking for the full label range
+        if (offset + labelLength + 1 > name.length) {
+            return (address(0), bytes32(0), offset);
+        }
+
         uint256 nextLabel = offset + labelLength + 1;
         bytes32 labelHash;
         if (


### PR DESCRIPTION
First commit

The findResolver(bytes, uint256) function in the UniversalResolver contract processes encrypted labels by identifying specific conditions, such as the presence of square brackets ([ ]) and a label length of 66 bytes. It then attempts to decode the encrypted portion of the label as a hex-encoded string using hexStringToBytes32. However, the function does not validate whether the hex-encoded data is well-formed or of the correct length before decoding. This can lead to unexpected reverts or incorrect calculations when the input data is malformed or does not conform to the expected structure.

Introduce explicit validations to ensure that the encrypted portion of the label meets the expected format before decoding it. Verify that the hex-encoded string contains only valid hexadecimal characters and that its length matches the required 64 characters (32 bytes).

Second commit

The findResolver(bytes, uint256) function in the UniversalResolver contract lacks comprehensive bounds validation for the offset and labelLength parameters. These parameters are used to index and slice the name array, but there is no explicit check ensuring that both offset and offset + labelLength + 1 remain within the array's bounds. This oversight can lead to out-of-bounds memory access, causing the function to revert unexpectedly when handling crafted or invalid inputs.
Add a validation step at the beginning of the findResolver function to ensure that offset is within the array's bounds and that the calculated range offset + labelLength + 1 does not exceed the length of the name array.