### PR TITLE
add check for even

### DIFF
--- a/src/resolver/libraries/HexUtils.sol
+++ b/src/resolver/libraries/HexUtils.sol
@@ -13,6 +13,8 @@ library HexUtils {
         pure
         returns (bytes32 r, bool valid)
     {
+        if ((lastIdx - idx) % 2 != 0) return (r, false);
+
         valid = true;
         assembly {
             // check that the index to read to is not past the end of the string

--- a/src/resolver/libraries/HexUtils.sol
+++ b/src/resolver/libraries/HexUtils.sol
@@ -14,6 +14,7 @@ library HexUtils {
         returns (bytes32 r, bool valid)
     {
         if ((lastIdx - idx) % 2 != 0) return (r, false);
+        if (idx >= lastIdx || lastIdx > str.length) return (bytes32(0), false);
 
         valid = true;
         assembly {


### PR DESCRIPTION
The hexStringToBytes32 function in the HexUtils library does not validate whether the substring defined by idx and lastIdx contains an even number of characters, which is essential for accurate hexadecimal parsing. When the range results in an odd-length substring, the function may produce incorrect or incomplete results, potentially impacting downstream processes that rely on the parsed output.

The hexStringToBytes32 function should include a validation step to ensure that the length of the substring between idx and lastIdx is even before performing any parsing operations.