### PR TITLE
add utf8 validations for _charLenght

### DIFF
--- a/test/utils/StringUtils.t.sol
+++ b/test/utils/StringUtils.t.sol
@@ -54,11 +54,21 @@ contract StringUtilsTest is Test {
         assertEq(actualCount, expectedCount, "Empty string character count should be zero");
     }
 
-    function test_invalidUTF8() public pure {
+    function test_invalidUTF8() public {
         // Malformed UTF-8 sequence (invalid start byte)
         bytes memory invalidBytes = hex"FF";
         string memory s = string(invalidBytes);
         uint256 expectedCount = 1; // Counts invalid byte as a character
+        vm.expectRevert(StringUtils.InvalidUTF8Byte.selector);
+        uint256 actualCount = s.strlen();
+        assertEq(actualCount, expectedCount, "Invalid UTF-8 character count mismatch");
+    }
+
+    function test_invalidContinuationByte() public {
+        bytes memory invalidBytes = "\xE2\x28\xA1";
+        string memory s = string(invalidBytes);
+        uint256 expectedCount = 1; // Counts invalid byte as a character
+        vm.expectRevert(StringUtils.InvalidUTF8Byte.selector);
         uint256 actualCount = s.strlen();
         assertEq(actualCount, expectedCount, "Invalid UTF-8 character count mismatch");
     }


### PR DESCRIPTION
The strlen function in the StringUtils library relies on _charLength to determine the byte length of each character. However, _charLength does not adequately validate whether the bytes conform to the UTF-8 standard. As a result, malformed UTF-8 sequences can cause strlen to misinterpret the input, leading to an incorrect character count. Specifically:

- Malformed UTF-8 strings may result in either over-counting or under-counting characters.
- This behavior could allow malicious users to bypass logic dependent on accurate character counts, such as pricing models, validations, or input restrictions.

For example:
- A string containing invalid UTF-8 bytes like \xE2\x28\xA1 might be misinterpreted as fewer characters than its actual length.
- Conversely, certain malformed sequences could appear as additional characters, affecting validations or cost calculations.

Validate input strings to ensure they conform to UTF-8 encoding before processing. This can be achieved by enhancing the _charLength function to detect and reject invalid sequences explicitly.