### PR TITLE
add check in readReturnData

### DIFF
--- a/src/resolver/libraries/LowLevelCallUtils.sol
+++ b/src/resolver/libraries/LowLevelCallUtils.sol
@@ -36,10 +36,14 @@ library LowLevelCallUtils {
      * @dev Reads return data from the most recent external call.
      * @param offset Offset into the return data.
      * @param length Number of bytes to return.
+     * @return data The copied return data
+     * @dev Reverts if offset + length exceeds returndatasize
      */
     function readReturnData(uint256 offset, uint256 length) internal pure returns (bytes memory data) {
         data = new bytes(length);
         assembly {
+            // Validate that offset + length <= returndatasize()
+            if gt(add(offset, length), returndatasize()) { revert(0, 0) }
             returndatacopy(add(data, 32), offset, length)
         }
     }


### PR DESCRIPTION
The readReturnData function in the LowLevelCallUtils library lacks proper validation of the offset and length parameters. If these parameters are crafted to exceed the available returndatasize(), the function will revert during the returndatacopy operation. This lack of validation does not follow best practices for handling external return data and can lead to disruptions in the resolution process within the UniversalResolver contract.

To ensure robustness and adhere to best practices, implement validation for the offset and length parameters in readReturnData. This will ensure that the parameters fall within the bounds of returndatasize() and prevent unintended reverts.