### PR TITLE
add check for multicall

### DIFF
--- a/src/resolver/UniversalResolver.sol
+++ b/src/resolver/UniversalResolver.sol
@@ -28,6 +28,9 @@ error ResolverWildcardNotSupported();
 /// @notice Thrown when the registry is invalid.
 error InvalidRegistry();
 
+/// @notice Thrown when the array lengths do not match.
+error ArrayLengthsMustMatch();
+
 struct MulticallData {
     bytes name;
     bytes[] data;
@@ -364,6 +367,8 @@ contract UniversalResolver is ERC165, Ownable {
 
     function _multicall(MulticallData memory multicallData) internal view returns (bytes[] memory results) {
         uint256 length = multicallData.data.length;
+        if (length != multicallData.failures.length) revert ArrayLengthsMustMatch();
+
         uint256 offchainCount = 0;
         OffchainLookupCallData[] memory callDatas = new OffchainLookupCallData[](length);
         OffchainLookupExtraData[] memory extraDatas = new OffchainLookupExtraData[](length);


### PR DESCRIPTION
The _multicall function in the UniversalResolver contract processes multiple arrays, such as multicallData.data and multicallData.failures, assuming their lengths are aligned. However, the function does not enforce strict equality between these arrays' lengths. If a mismatch occurs, the loop in _multicall may process data incorrectly or leave some entries unprocessed.

Ensure that all related arrays, including multicallData.data and multicallData.failures, have strictly equal lengths before processing.