### PR TITLE
removed reclaim function from BaseRegistrar

### DIFF
--- a/src/registrar/types/BaseRegistrar.sol
+++ b/src/registrar/types/BaseRegistrar.sol
@@ -270,7 +270,6 @@ contract BaseRegistrar is ERC721, Ownable {
         return expires;
     }
 
-
     /// @notice ERC165 compliant signal for interface support.
     /// @param interfaceID the ERC165 iface id being checked for compliance
     /// @return bool Whether this contract supports the provided interfaceID

--- a/src/registrar/types/BaseRegistrar.sol
+++ b/src/registrar/types/BaseRegistrar.sol
@@ -270,15 +270,6 @@ contract BaseRegistrar is ERC721, Ownable {
         return expires;
     }
 
-    /// @notice Reclaim ownership of a name in BNS registry, if you own it in the registrar.
-    /// @param id The id of the name to reclaim.
-    /// @param owner The address of the owner that will be set in the Registry.
-    function reclaim(uint256 id, address owner) external live {
-        if (!_isApprovedOrOwner(msg.sender, id)) {
-            revert NotApprovedOwner(id, owner);
-        }
-        registry.setSubnodeOwner(baseNode, bytes32(id), owner);
-    }
 
     /// @notice ERC165 compliant signal for interface support.
     /// @param interfaceID the ERC165 iface id being checked for compliance


### PR DESCRIPTION
The reclaim function in the BaseRegistrar contract allows a user to transfer the registry ownership of a node to another address without changing the NFT ownership. This functionality enables users to update the registry owner to a different address, even if it is not the current NFT owner. While this behavior is intentional, it might not always be advisable, as transferring registry ownership to another party effectively relinquishes control over the node.

Additionally, the transferFrom method in the contract ensures that registry ownership is automatically updated when the NFT is transferred. This design prevents discrepancies in typical workflows where NFT ownership and registry ownership would naturally align. However, using the reclaim function to assign registry ownership to a separate address could still create scenarios where the NFT owner and registry owner differ, leading to potential inconsistencies or unintended loss of control.