### PR TITLE
removed register and registerOnly from BaseRegistrar

### DIFF
--- a/src/registrar/types/BaseRegistrar.sol
+++ b/src/registrar/types/BaseRegistrar.sol
@@ -197,28 +197,6 @@ contract BaseRegistrar is ERC721, Ownable {
         registry.setResolver(baseNode, resolver);
     }
 
-    /// @notice Register a name.
-    ///
-    /// @param id The token id determined by keccak256(label).
-    /// @param owner The address that should own the registration.
-    /// @param duration Duration in seconds for the registration.
-    ///
-    /// @return The expiry date of the registered name.
-    function register(uint256 id, address owner, uint256 duration) external returns (uint256) {
-        return _register(id, owner, duration, true);
-    }
-
-    /// @notice Register a name without modifying the Registry.
-    ///
-    /// @param id The token id determined by keccak256(label).
-    /// @param owner The address that should own the registration.
-    /// @param duration Duration in seconds for the registration.
-    ///
-    /// @return The expiry date of the registered name.
-    function registerOnly(uint256 id, address owner, uint256 duration) external returns (uint256) {
-        return _register(id, owner, duration, false);
-    }
-
     /// @notice Register a name and add details to the record in the Registry.
     /// @param id The token id determined by keccak256(label).
     /// @param owner The address that should own the registration.


### PR DESCRIPTION
The register and registerOnly functions in the BaseRegistrar contract both invoke the _register function, which is restricted by the onlyController modifier. However, no contract or address with onlyController privileges is calling these functions, rendering them effectively unused in the current implementation.

The presence of unused functions increases the complexity of the contract and the potential attack surface, even if the functions are restricted. Additionally, these functions occupy space in the deployed bytecode, resulting in slightly higher deployment costs without contributing to the contract's functionality.

While these functions might have been added for future use or integration, their lack of utilization in the current implementation raises questions about their necessity.
